### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ In addition, we also developed a custom function on the Sketch called seanBlinke
 This function can be executed directly from Node.js as we included the definition for the custom function as the command in Firmata.h header file:
 
 <pre>
-#define SET_SEAN_BLINKER        0xF1 // set a pin to INPUT/OUTPUT/PWM/etc
+# define SET_SEAN_BLINKER        0xF1 // set a pin to INPUT/OUTPUT/PWM/etc
 </pre>
 
 as well as in Firmata.cpp file:

--- a/dev/node_modules/cylon-firmata/node_modules/cylon-gpio/docs/events_ir_range_finder.md
+++ b/dev/node_modules/cylon-firmata/node_modules/cylon-gpio/docs/events_ir_range_finder.md
@@ -1,4 +1,4 @@
-#Events
+# Events
 
 ## start 
 

--- a/dev/node_modules/cylon-gpio/docs/events_ir_range_finder.md
+++ b/dev/node_modules/cylon-gpio/docs/events_ir_range_finder.md
@@ -1,4 +1,4 @@
-#Events
+# Events
 
 ## start 
 

--- a/dev/node_modules/firmata/readme.md
+++ b/dev/node_modules/firmata/readme.md
@@ -1,21 +1,21 @@
 [![Build Status](https://secure.travis-ci.org/jgautier/firmata.png)](http://travis-ci.org/jgautier/firmata)
-#Firmata
+# Firmata
 A Node library to interact with an Arduino running the firmata protocol.
-#Install
+# Install
     npm install -g firmata
-#Tests
+# Tests
 The tests are written with expresso and assume you have the async library install globally.  It also assumes you have an Arduino Uno running firmata 2.2 with a photocell and an LED hooked up.
-#Usage
+# Usage
     
     var firmata = require('firmata');
     var board = new firmata.Board('path to usb',function(){
       //arduino is ready to communicate
     });  
-#REPL
+# REPL
 If you run *firmata* from the command line it will prompt you for the usb port.  Then it will present you with a REPL with a board variable available.
-#Board
+# Board
   The Board object is where all the functionality is for the library.
-##attributes
+## attributes
   *Board.MODES*
     
     {
@@ -52,7 +52,7 @@ If you run *firmata* from the command line it will prompt you for the usb port. 
   For example to get the analog pin 5 from the *Board.pins* attributes use:
 
     board.pins[board.analogPins[5]];
-##methods
+## methods
     board.pinMode(pin,mode)
 
   Set a mode for a pin.  pin is the number of the pin and the mode is on of the Board.MODES values.

--- a/dev/node_modules/npm/node_modules/npmconf/node_modules/config-chain/readme.markdown
+++ b/dev/node_modules/npm/node_modules/npmconf/node_modules/config-chain/readme.markdown
@@ -1,4 +1,4 @@
-#config-chain
+# config-chain
 
 USE THIS MODULE TO LOAD ALL YOUR CONFIGURATIONS
 
@@ -56,7 +56,7 @@ USE THIS MODULE TO LOAD ALL YOUR CONFIGURATIONS
 
 FINALLY, EASY FLEXIBLE CONFIGURATIONS!
 
-##see also: [proto-list](https://github.com/isaacs/proto-list/)
+## see also: [proto-list](https://github.com/isaacs/proto-list/)
 
 WHATS THAT YOU SAY?
 

--- a/dev/node_modules/npm/node_modules/retry/Readme.md
+++ b/dev/node_modules/npm/node_modules/retry/Readme.md
@@ -154,7 +154,7 @@ Returns an int representing the number of attempts it took to call `fn` before i
 retry is licensed under the MIT license.
 
 
-#Changelog
+# Changelog
 
 0.6.0 Introduced optional timeOps parameter for the attempt() function which is an object having a property timeout in miliseconds and a property cb callback function. Whenever your retry operation takes longer than timeout to execute, the timeout callback function cb is called.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
